### PR TITLE
1- Fixed issues with broken links, 2- Added counter of return codes to output

### DIFF
--- a/link/parse.go
+++ b/link/parse.go
@@ -10,11 +10,9 @@ import (
 
 //This represents an 'a' html tag with href (URL)
 type Link struct {
-	
 	Href string
 	Text string
 	Code int
-
 }
 
 //Parse will take in an HTML document and will return a slice of links parsed from it.
@@ -34,7 +32,7 @@ func Parse(r io.Reader) ([]Link, error) {
 	for _, node := range nodes {
 		links = append(links, buildLink(node))
 	}
-	
+
 	return links, nil
 
 }
@@ -106,12 +104,20 @@ func Fixlinks(links []Link, url string) []Link {
 	var temp = zp.Split(url, -1)
 	var domainname = temp[0] + "//" + temp[2]
 
-	//Build array of hrefs
+	//Fix broken URLs then create new array with the new values
 	var newlinks []Link
 	for i := 0; i < len(links); i++ {
 		var path = links[i].Href
 		if strings.HasPrefix(path, "/") {
 			path = domainname + path
+		}
+
+		if strings.HasPrefix(path, "#") {
+			path = domainname + path
+		}
+
+		if !strings.HasPrefix(path, "http") && path != "" {
+			path = domainname + "/" + path
 		}
 
 		var newlink Link

--- a/web/web.go
+++ b/web/web.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"strconv"
 
 	"github.com/bluesNbrews/ParseWebPage/link"
 )
@@ -15,9 +16,9 @@ var counter int = 0
 
 //Gethtml makes a GET call to a URL and returns the HTML body
 func Gethtml(enteredurl string) io.Reader {
-	
+
 	resp, err := http.Get(enteredurl)
-	
+
 	if err != nil {
 		panic(err)
 	}
@@ -30,35 +31,39 @@ func Gethtml(enteredurl string) io.Reader {
 
 }
 
-//Get http respone code for each link passed in. Use channel to pass back response code, 
+//Get http respone code for each link passed in. Use channel to pass back response code,
 //which will be concurrently assigned and printed via UpdateAndPrint
 func GetUrlStatus(newlinks link.Link, c chan int) {
-		
-	//Get the response or error from GET request. They are both mutually exclusive (returns one or the other) 
+
+	//Get the response or error from GET request. They are both mutually exclusive (returns one or the other)
 	resp, err := http.Get(newlinks.Href)
 
 	//If there is an error, the error will be logged and the program will exit
 	//Lastly, the error will be displayed after the program closes
 	//There may be other functions to replace log.Fatal, but I had a hard time finding and implementing one
 	if err != nil {
-	
+
 		log.Fatal(err)
 
-	} 
-	defer resp.Body.Close()		
+	}
+	defer resp.Body.Close()
 
 	//Pass the status code via channel
 	c <- resp.StatusCode
- 
+
 }
 
-//Update the status code for the new links
-func UpdateAndPrint(newlinks link.Link, c chan int){
-	
+//UpdateAndPrint updates the status code for the new links and prints the output
+func UpdateAndPrint(newlinks link.Link, c chan int, codestable map[string]int) {
+
 	//Receive and assign status code via channel (waits for send)
-	newlinks.Code = <- c
+	newlinks.Code = <-c
 
 	//Print table rows
 	fmt.Printf("| %-3d | %-120s | %-60s | %-3d |\n", counter, newlinks.Href, newlinks.Text, newlinks.Code)
 	counter++
+
+	//Increment the HTTP return code counter by 1
+	codestable[strconv.Itoa(newlinks.Code)]++
+
 }


### PR DESCRIPTION
This update includes fixes for URLs that start with the character "#". It also displays at the end of the output the count of each HTTP return code